### PR TITLE
Add init_selinon() back

### DIFF
--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -3,9 +3,12 @@ import flask
 from flask import Flask, request
 from flask_cors import CORS
 from utils import DatabaseIngestion, scan_repo, validate_request_data
+from f8a_worker.setup_celery import init_selinon
 
 app = Flask(__name__)
 CORS(app)
+
+init_selinon()
 
 
 @app.route('/api/v1/readiness')
@@ -37,9 +40,9 @@ def register():
     updates existing repo information.
     """
     resp_dict = {
-                 "data": [],
-                 "success": True,
-                 "summary": "{} successfully registered"
+        "data": [],
+        "success": True,
+        "summary": "{} successfully registered"
     }
     input_json = request.get_json()
     if request.content_type != 'application/json':

--- a/src/utils.py
+++ b/src/utils.py
@@ -200,10 +200,8 @@ def server_run_flow(flow_name, flow_args):
     """
     logger.info('Running flow {}'.format(flow_name))
     start = datetime.datetime.now()
-
     init_celery(result_backend=False)
     dispacher_id = run_flow(flow_name, flow_args)
-
     elapsed_seconds = (datetime.datetime.now() - start).total_seconds()
     logger.info("It took {t} seconds to start {f} flow.".format(
         t=elapsed_seconds, f=flow_name))


### PR DESCRIPTION
`init_selinon()` was removed in https://github.com/fabric8-analytics/fabric8-gemini-server/commit/79c2946f7cb28df1602e98ea8074ca13844f78dd#diff-e4e95f0c8626ae81416f8fa5477fbfa1L206 and hence the deployments were failing. Adding it back to attain expected behavior. @GeetikaBatra was there any reason to remove it? 