### PR TITLE
Change response of register endpoint to reflect scan report

### DIFF
--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -1,8 +1,8 @@
 """Definition of the routes for gemini server."""
 import flask
-from flask import Flask, request
+from flask import Flask, request, current_app
 from flask_cors import CORS
-from utils import DatabaseIngestion, scan_repo, validate_request_data
+from utils import DatabaseIngestion, scan_repo, validate_request_data, retrieve_worker_result
 from f8a_worker.setup_celery import init_selinon
 
 app = Flask(__name__)
@@ -34,15 +34,14 @@ def scan():
 @app.route('/api/v1/register', methods=['POST'])
 def register():
     """
-    Endpoint for registering a new repositor.
+    Endpoint for registering a new repository.
 
     Registers new information and
     updates existing repo information.
     """
     resp_dict = {
-        "data": [],
         "success": True,
-        "summary": "{} successfully registered"
+        "summary": ""
     }
     input_json = request.get_json()
     if request.content_type != 'application/json':
@@ -55,21 +54,81 @@ def register():
         resp_dict["success"] = False
         resp_dict["summary"] = validated_data[1]
         return flask.jsonify(resp_dict), 404
+
     try:
-        status = DatabaseIngestion.store_record(input_json)
-        resp_dict["data"] = status
-    except Exception as e:
+        repo_info = DatabaseIngestion.get_info(input_json.get('git-url'))
+        if repo_info.get('is_valid'):
+            data = repo_info.get('data')
+            git_sha = data["git_sha"]
+            # Update the record to reflect new git_sha if any.
+            DatabaseIngestion.update_data(input_json)
+        else:
+            try:
+                DatabaseIngestion.store_record(input_json)
+                status = scan_repo(input_json)
+                if status is not True:
+                    resp_dict["success"] = False
+                    resp_dict["summary"] = "New Repo Scan Initialization Failure"
+                    return flask.jsonify(resp_dict), 500
+
+                resp_dict["summary"] = "Repository {} with commit-hash {} " \
+                                       "has been successfully registered. " \
+                                       "Please check back for report after some time." \
+                    .format(input_json.get('git-url'),
+                            input_json.get('git-sha'))
+
+                return flask.jsonify(resp_dict), 200
+            except Exception as e:
+                resp_dict["success"] = False
+                resp_dict["summary"] = "Database Ingestion Failure due to: {}" \
+                    .format(e)
+                return flask.jsonify(resp_dict), 500
+    except Exception:
         resp_dict["success"] = False
-        resp_dict["summary"] = "Database Ingestion Failure due to" + str(e)
+        resp_dict["summary"] = "Cannot get information about repository {}" \
+            .format(input_json.get('git-url'))
         return flask.jsonify(resp_dict), 500
 
-    status = scan_repo(input_json)
-    if status is not True:
-        resp_dict["success"] = False
-        resp_dict["summary"] = "New Repo Scan Initializtion Failure"
-        return flask.jsonify(resp_dict), 500
-    rep_summary = resp_dict["summary"].format(input_json['git-url'])
-    resp_dict["summary"] = rep_summary
+    # Checks if data is defined and compares new git_sha with old.
+    is_new_commit_hash = input_json.get("git-sha") != data["git_sha"]
+
+    worker_result = retrieve_worker_result(git_sha, "ReportGenerationTask")
+    if worker_result:
+        resp_dict["summary"] = "Repository {} with commit-hash {} " \
+                               "has already been registered and scanned. " \
+                               "Please check the scan report for details. " \
+            .format(input_json.get('git-url'),
+                    input_json.get('git-sha'))
+
+        if is_new_commit_hash:
+            resp_dict["summary"] = "Repository {} with commit-hash {} " \
+                                   "has already been registered and scanned. " \
+                                   "Please check the scan report for details. " \
+                                   "You can check the report for commit-hash {} after" \
+                                   "some time." \
+                .format(input_json.get('git-url'),
+                        data["git_sha"], input_json.get("git-sha"))
+
+        task_result = worker_result.get('task_result')
+        if task_result:
+            resp_dict.update({
+                "last_scanned_at": task_result.get('scanned_at'),
+                "last_scan_report": task_result.get('dependencies')
+            })
+            return flask.jsonify(resp_dict), 200
+        else:
+            resp_dict["success"] = False
+            resp_dict["summary"] = "Failed to retrieve scan report."
+            return flask.jsonify(resp_dict), 500
+
+    resp_dict.update({
+        "summary": "Repository {} was already registered, but no report for "
+                   "commit-hash {} was found. Please check back later."
+                   .format(input_json.get('git-url'), git_sha),
+        "last_scanned_at": data['last_scanned_at'],
+        "last_scan_report": None
+    })
+
     return flask.jsonify(resp_dict), 200
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 import os
 
 from flask import current_app
-from f8a_worker.models import OSIORegisteredRepos
+from f8a_worker.models import OSIORegisteredRepos, WorkerResult
 from sqlalchemy import create_engine
 from f8a_worker.models import Base
 import pytest
@@ -35,3 +35,4 @@ def create_database():
     engine = create_engine(connection)
     Base.metadata.drop_all(engine)
     OSIORegisteredRepos.__table__.create(engine)
+    WorkerResult.__table__.create(engine)

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -42,18 +42,3 @@ def test_liveness_endpoint(client):
     response = client.get(api_route_for("liveness"))
     assert response.status_code == 200
     json_data = get_json_from_response(response)
-
-
-def test_register_api_endpoint(client, mocker):
-    """Test function for register endpoint."""
-    create_database()
-    scan_mock = mocker.patch("src.rest_api.scan_repo")
-    scan_mock.return_value = True
-    reg_resp = client.post(api_route_for("register"),
-                           data=json.dumps(payload), content_type='application/json')
-    assert reg_resp.status_code == 200
-    jsn = get_json_from_response(reg_resp)
-    assert(jsn["success"])
-    assert(jsn['data']["data"]["git_sha"] == payload["git-sha"])
-    assert(jsn['data']["data"]["git_url"] == payload["git-url"])
-    assert(jsn['data']["data"]["email_ids"] == payload["email-ids"])


### PR DESCRIPTION
The response of `/register` endpoint is now reflecting the latest https://github.com/fabric8-analytics/fabric8-gemini-server/blob/master/swagger.yaml spec.