### PR TITLE
Use query.first() instead of query.one()

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -64,9 +64,7 @@ def retrieve_worker_result(external_request_id, worker):
         query = session.query(WorkerResult) \
             .filter(WorkerResult.external_request_id == external_request_id,
                     WorkerResult.worker == worker)
-        result = query.one()
-    except (NoResultFound, MultipleResultsFound):
-        return None
+        result = query.first()
     except SQLAlchemyError:
         session.rollback()
         raise


### PR DESCRIPTION
- query.one() raises MultipleResultsFoundException, but we actually want a single result out of many and hence query.first().