### PR TITLE
Remove installation of python34-virtualenv

### DIFF
--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -12,9 +12,9 @@ load_jenkins_vars() {
 
 prep() {
     yum -y update
-    yum -y install docker git which epel-release  postgresql
+    yum -y install docker git which epel-release postgresql
     yum -y install python34-pip
-    pip3 install virtualenv==15.2.0
+    pip3 install virtualenv
     pip3 install docker-compose
     systemctl start docker
 }


### PR DESCRIPTION
- We don't need python34-virtualenv since we already use pip install virtualenv.
- Also, with virtualenv version 16.0.0 it seems to create issues while installing the package.