### PR TITLE
Add unit tests for newly introduced endpoints

### DIFF
--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -146,7 +146,7 @@ def report():
 
 @app.route('/api/v1/user-repo/scan', methods=['POST'])
 @login_required
-def user_repo_scan():  # pragma: no cover
+def user_repo_scan():
     """
     Endpoint for scanning an OSIO user's repository.
 
@@ -167,7 +167,9 @@ def user_repo_scan():  # pragma: no cover
     validate_string = "{} cannot be empty"
     if 'git-url' not in input_json:
         validate_string = validate_string.format("git-url")
-        return False, validate_string
+        resp_dict["status"] = 'failure'
+        resp_dict["summary"] = validate_string
+        return flask.jsonify(resp_dict), 400
 
     # Call the worker flow to run a user repository scan asynchronously
     status = alert_user(input_json, SERVICE_TOKEN)
@@ -187,7 +189,7 @@ def user_repo_scan():  # pragma: no cover
 
 @app.route('/api/v1/user-repo/notify', methods=['POST'])
 @login_required
-def notify_user():  # pragma: no cover
+def notify_user():
     """
     Endpoint for notifying security vulnerability in a repository.
 
@@ -208,8 +210,7 @@ def notify_user():  # pragma: no cover
     validate_string = "{} cannot be empty"
     if 'epv_list' not in input_json:
         resp_dict["status"] = "failure"
-        resp_dict["summary"] = "Required parameter 'epv_list' is missing " \
-                               "in the request"
+        resp_dict["summary"] = validate_string.format('epv_list')
         return flask.jsonify(resp_dict), 400
 
     # Call the worker flow to run a user repository scan asynchronously

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -180,25 +180,72 @@ def test_register_endpoint_6(get_info, client):
     assert reg_resp.status_code == 500
 
 
-# def test_scan_endpoint(client):
-#     """Test the /api/v1/user-repo/scan endpoint."""
-#     reg_resp = client.post(api_route_for('user-repo/scan'),
-#                            data=json.dumps(payload_user_repo_scan_drop),
-#                            content_type='application/json')
-#     assert reg_resp.status_code == 200
-#
-#
-# def test_drop_endpoint(client):
-#     """Test the /api/v1/user-repo/drop endpoint."""
-#     reg_resp = client.post(api_route_for('user-repo/scan'),
-#                            data=json.dumps(payload_user_repo_scan_drop),
-#                            content_type='application/json')
-#     assert reg_resp.status_code == 200
-#
-#
-# def test_notify_endpoint(client):
-#     """Test the /api/v1/user-repo/notify endpoint."""
-#     reg_resp = client.post(api_route_for('user-repo/scan'),
-#                            data=json.dumps(payload_user_repo_notify),
-#                            content_type='application/json')
-#     assert reg_resp.status_code == 200
+def test_user_repo_scan_endpoint(client):
+    """Test the /api/v1/user-repo/scan endpoint."""
+    resp = client.post(api_route_for('user-repo/scan'),
+                       data=json.dumps(payload))
+
+    assert resp.status_code == 400
+
+
+def test_user_repo_scan_endpoint_1(client):
+    """Test the /api/v1/user-repo/scan endpoint."""
+    resp = client.post(api_route_for('user-repo/scan'),
+                       data=json.dumps(payload_1),
+                       content_type='application/json')
+
+    assert resp.status_code == 400
+
+
+@patch("src.rest_api.alert_user")
+def test_user_repo_scan_endpoint_2(alert_user, client):
+    """Test the /api/v1/user-repo/scan endpoint."""
+    alert_user.return_value = False
+    resp = client.post(api_route_for('user-repo/scan'),
+                       data=json.dumps(payload),
+                       content_type='application/json')
+
+    assert resp.status_code == 500
+
+    alert_user.return_value = True
+    resp = client.post(api_route_for('user-repo/scan'),
+                       data=json.dumps(payload),
+                       content_type='application/json')
+
+    assert resp.status_code == 200
+
+
+def test_notify_user_endpoint(client):
+    """Test the /api/v1/user-repo/notify endpoint."""
+    resp = client.post(api_route_for('user-repo/notify'),
+                       data=json.dumps(payload))
+
+    assert resp.status_code == 400
+
+
+def test_notify_user_endpoint_1(client):
+    """Test the /api/v1/user-repo/notify endpoint."""
+    resp = client.post(api_route_for('user-repo/notify'),
+                       data=json.dumps(payload),
+                       content_type='application/json')
+
+    assert resp.status_code == 400
+
+
+@patch('src.rest_api.alert_user')
+def test_notify_user_endpoint_2(alert_user, client):
+    """Test the /api/v1/user-repo/notify endpoint."""
+    alert_user.return_value = False
+    resp = client.post(api_route_for('user-repo/notify'),
+                       data=json.dumps(payload_user_repo_notify),
+                       content_type='application/json')
+
+    assert resp.status_code == 500
+
+    alert_user.return_value = True
+
+    resp = client.post(api_route_for('user-repo/notify'),
+                       data=json.dumps(payload_user_repo_notify),
+                       content_type='application/json')
+
+    assert resp.status_code == 200

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -207,3 +207,14 @@ def test_fetch_public_key_2(a):
     resp = fetch_public_key(app)
     assert resp == \
         '-----BEGIN PUBLIC KEY-----\ntest\n-----END PUBLIC KEY-----'
+
+
+@patch("src.utils.server_run_flow", return_value="d_id")
+def test_alert_user(server_run_flow):
+    """Test alert user mechanism."""
+    resp = alert_user({
+        'git-url': 'git-repo',
+        'email-ids': 'dummy'
+    }, service_token='test', epv_list=['test'])
+
+    assert resp is True


### PR DESCRIPTION
- Add tests for 'user-repo/scan' and 'user-repo/notify' endpoints as well as 'alert_user' function.
- Modify the response of 'user-repo/scan' endpoint in case of missing 'git-url' to return json response along with status code.