### PR TITLE
Notify CCP about missing lock file

### DIFF
--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -129,13 +129,21 @@ def report():
                 "scanned_at": task_result.get("scanned_at"),
                 "dependencies": task_result.get("dependencies")
             })
+
+            if task_result.get('lock_file_absent'):
+                response.update({
+                    "lock_file_absent": task_result.get("lock_file_absent"),
+                    "message": task_result.get("message")
+                })
+                return flask.jsonify(response), 400
+
             return flask.jsonify(response), 200
         else:
             response.update({
                 "status": "failure",
                 "message": "Failed to retrieve scan report"
             })
-            return flask.jsonify(response), 404
+            return flask.jsonify(response), 500
     else:
         response.update({
             "status": "failure",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -78,10 +78,14 @@ paths:
           schema:
             $ref: "#/definitions/Report"
           description: Scan report for given registered repository
+        '400':
+          description: Bad request from the client
         '401':
           description: Request unauthorized
         '404':
           description: Data not found
+        '500':
+          description: Internal server error
   '/user-repo/scan':
     post:
       tags:
@@ -217,6 +221,10 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Dependency'
+      lock_file_absent:
+        type: boolean
+      message:
+        type: string
   Repo:
     title: Github Details
     description: Github Details

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -72,7 +72,7 @@ def test_report_endpoint(mocker, client):
         "task_result": None
     }
     response = client.get(api_route_for('report?git-url=test&git-sha=test'))
-    assert response.status_code == 404
+    assert response.status_code == 500
     json_data = get_json_from_response(response)
     assert json_data == {
         "status": "failure",
@@ -92,6 +92,25 @@ def test_report_endpoint(mocker, client):
         "git_sha": "test",
         "scanned_at": "1",
         "dependencies": []
+    }
+    mocker.return_value = {
+        "task_result": {
+            "scanned_at": "1",
+            "dependencies": [],
+            "lock_file_absent": True,
+            "message": "test"
+        }
+    }
+    response = client.get(api_route_for('report?git-url=test&git-sha=test'))
+    assert response.status_code == 400
+    json_data = get_json_from_response(response)
+    assert json_data == {
+        "git_url": "test",
+        "git_sha": "test",
+        "scanned_at": "1",
+        "dependencies": [],
+        "lock_file_absent": True,
+        "message": "test"
     }
 
 


### PR DESCRIPTION
- Returns error code 400 if lock file is absent in the repository while performing internal scan