### PR TITLE
Added cve source sync job 

### DIFF
--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -32,6 +32,7 @@ _SERVICE_HOST = os.environ.get("BAYESIAN_DATA_IMPORTER_SERVICE_HOST", "bayesian-
 _SERVICE_PORT = os.environ.get("BAYESIAN_DATA_IMPORTER_SERVICE_PORT", "9192")
 _CVE_SYNC_ENDPOINT = "api/v1/sync_latest_non_cve_version"
 _LATEST_VERSION_SYNC_ENDPOINT = "api/v1/sync_latest_version"
+_CVE_SOURCE_SYNC_ENDPOINT = "api/v1/sync_cve_source"
 
 SERVICE_TOKEN = 'token'
 try:
@@ -65,7 +66,8 @@ def sync_data():
     valid input: {
         "non_cve_sync": true/false,
         "latest_version_sync": true/false,
-        "cve_ecosystem": ['maven', 'pypi, 'npm']
+        "cve_ecosystem": ['maven', 'pypi, 'npm'],
+        "cve_source_sync: {'cve_sources': 'CRA','ecosystems': ['npm']}
     }
 
     """
@@ -98,6 +100,16 @@ def sync_data():
         logger.info("Calling latest version sync with 'all'")
         _session.post(url, json=['all'])
         resp['message'] = resp['message'] + " for latest version"
+
+    cve_source_sync = input_json.get('cve_source_sync', False)
+    if cve_source_sync:
+        url = "http://{host}:{port}/{endpoint}".format(host=_SERVICE_HOST,
+                                                       port=_SERVICE_PORT,
+                                                       endpoint=_CVE_SOURCE_SYNC_ENDPOINT)
+        logger.info("Calling latest cve source sync")
+        _session.post(url, json=cve_source_sync)
+        resp['message'] = resp['message'] + " for cve source update"
+
     logger.info("Sync operation called.. Message->", resp['message'])
     return flask.jsonify(resp), 200
 

--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -67,7 +67,7 @@ def sync_data():
         "non_cve_sync": true/false,
         "latest_version_sync": true/false,
         "cve_ecosystem": ['maven', 'pypi, 'npm'],
-        "cve_source_sync: {'cve_sources': 'CRA'}
+        "cve_source_sync": {'cve_sources': 'CRA'}
     }
 
     """
@@ -101,8 +101,8 @@ def sync_data():
         _session.post(url, json=['all'])
         resp['message'] = resp['message'] + " for latest version"
 
-    cve_source_sync = input_json.get('cve_source_sync', False)
-    if cve_source_sync:
+    cve_source_sync = input_json.get('cve_source_sync', {})
+    if cve_source_sync != {}:
         url = "http://{host}:{port}/{endpoint}".format(host=_SERVICE_HOST,
                                                        port=_SERVICE_PORT,
                                                        endpoint=_CVE_SOURCE_SYNC_ENDPOINT)

--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -67,7 +67,7 @@ def sync_data():
         "non_cve_sync": true/false,
         "latest_version_sync": true/false,
         "cve_ecosystem": ['maven', 'pypi, 'npm'],
-        "cve_source_sync: {'cve_sources': 'CRA','ecosystems': ['npm']}
+        "cve_source_sync: {'cve_sources': 'CRA'}
     }
 
     """
@@ -107,6 +107,7 @@ def sync_data():
                                                        port=_SERVICE_PORT,
                                                        endpoint=_CVE_SOURCE_SYNC_ENDPOINT)
         logger.info("Calling latest cve source sync")
+        cve_source_sync['ecosystems'] = input_json.get('cve_ecosystem', [])
         _session.post(url, json=cve_source_sync)
         resp['message'] = resp['message'] + " for cve source update"
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -282,6 +282,11 @@ definitions:
           type: string
       latest_version_sync:
         type: boolean
+      cve_source_sync:
+        type: object
+        properties:
+          cve_sources:
+            type: string
   syncresp:
     title: Sync operation response
     description: Sync non cve version and latest version response

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -187,6 +187,15 @@ def test_sync_data1(_mock1, client):
                            content_type='application/json')
     assert response.status_code == 200
 
+    inp = '''{
+           "cve_source_sync": {"cve_sources": "CRA"},
+           "cve_ecosystem": ["npm"]
+        }'''
+    response = client.post(url,
+                           data=inp,
+                           content_type='application/json')
+    assert response.status_code == 200
+
 
 @patch("src.rest_api.retrieve_worker_result")
 def test_report_endpoint(mocker, client):


### PR DESCRIPTION
Added an input criteria to the /api/v1/sync-graph-data API to invoke cve source sync job for updating the default cve source in the existing cve node.